### PR TITLE
Make build scripts work on Windows

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,7 +25,7 @@ const extensionPath = path.resolve(
   "../continue/extensions/vscode/src",
 );
 const extensionFilter = new RegExp(
-  "^" + escapeForRegExp(extensionPath) + "/.*\\.ts$",
+  "^" + escapeForRegExp(extensionPath + path.sep) + ".*\\.ts$",
 );
 
 const namespaceSubstitutions = [

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -4,6 +4,8 @@
 const fs = require("fs").promises;
 const path = require("path");
 const {
+  NPM,
+  NPX,
   runCommand,
   findCommonPathRoot,
   expandTemplate,
@@ -355,12 +357,12 @@ async function copyPackageAssets(target) {
 async function buildSidebarUi() {
   console.log("\nBuilding Sidebar UI…");
   const guiDir = path.resolve(projectRoot, "continue/gui/");
-  await runCommand("npm: ", "npm run build", guiDir);
+  await runCommand("npm: ", `${NPM} run build`, guiDir);
 }
 
 async function runVsce(isPreRelease, target) {
   console.log("\nPackaging extension…");
-  let command = ["npx", "vsce", "package", "--out", "./build"];
+  let command = [NPX, "vsce", "package", "--out", "./build"];
   if (isPreRelease) {
     command.push("--pre-release");
   }

--- a/scripts/install-dependencies.js
+++ b/scripts/install-dependencies.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const { promisify } = require("util");
 const fs = require("fs").promises;
-const { runCommand, expandTemplate } = require("./utils.js");
+const { NPM, runCommand, expandTemplate } = require("./utils.js");
 
 // The glob and minimatch modules may not be available until after nodeModulesInstallation returns
 // so they'll get imported later
@@ -170,7 +170,7 @@ async function nodeModulesInstallation(packageDir) {
 
   try {
     await runCommand("npm:     ", [
-      "npm",
+      NPM,
       "install",
       "--no-fund",
       "--no-audit",
@@ -313,7 +313,7 @@ async function platformDependenciesInstallation(target) {
 
       await fs.mkdir(outputDir, { recursive: true });
       await runCommand("npm:     ", [
-        "npm",
+        NPM,
         "install",
         ...expandedInputModules,
         "--architecture=" + architecture,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -2,6 +2,9 @@ const path = require("path");
 const { spawn } = require("child_process");
 const { Transform } = require("stream");
 
+exports.NPM = process.platform == "win32" ? "npm.cmd" : "npm";
+exports.NPX = process.platform == "win32" ? "npx.cmd" : "npx";
+
 function waitForSubprocess(subprocess, command) {
   return new Promise((resolve, reject) => {
     subprocess.on("close", (code) => {


### PR DESCRIPTION
`npm` and `npx` have to be spawned as `npm.cmd` and `npx.cmd`; We could use cross-spawn, but we want to avoid dependencies in install-dependencies.