### PR TITLE
Transform EXTENSION_NAME and control plane info

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -77,6 +77,37 @@ const namespaceTransformPlugin = makeTransformPlugin({
   ],
 });
 
+const controlPlaneTransformPlugin = makeTransformPlugin({
+  name: "granite-control-plane-transform",
+  basePath: "continue/core/control-plane",
+  substitutions: [
+    // This among other things, transforms EXTENSION_NAME
+    {
+      pattern: /^continue$/,
+      replacement: "granite",
+    },
+    // This doesn't matter but, transform to match "continue"
+    {
+      pattern: /^continue-staging$/,
+      replacement: "granite-staging",
+    },
+    // These make sure we we don't make API calls to continue.dev
+    // or their SaaS providers
+    {
+      pattern: /continue[.]dev/,
+      replacement: "example.com",
+    },
+    {
+      pattern: /[.]run[.]app/,
+      replacement: ".example.com",
+    },
+    {
+      pattern: /[.]workos[.]com/,
+      replacement: ".example.com",
+    },
+  ],
+});
+
 const buildConfig = {
   entryPoints: ["./extension.ts"],
   bundle: true,
@@ -87,7 +118,7 @@ const buildConfig = {
   sourcemap: true,
   sourcesContent: true,
   outfile: "./out/index.js",
-  plugins: [namespaceTransformPlugin],
+  plugins: [namespaceTransformPlugin, controlPlaneTransformPlugin],
   platform: "node",
 
   // Workaround, see: https://github.com/evanw/esbuild/issues/1492#issuecomment-893144483


### PR DESCRIPTION
Extend the transform code to transform strings within core/control-plane:

 * The EXTENSION_NAME constant
 * Some other identifiers
 * URLS to continue.dev and SaaS providers (changed to example.com)

The EXTENSION_NAME transform is needed to get config settings working properly, since we lookup configuration settings under EXTENSION_NAME.<setting>.

***NOTE***: This includes the last commit in #53 - it will need rebasing after that is merged.