### PR TITLE
build: Don't duplicate sqlite3 modules in package

### DIFF
--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -122,15 +122,6 @@ const packageConfiguration = {
     },
     {
       description:
-        "SQLite3 binary libraries for {os} ({arch}) in cross-platform directory",
-      inputFiles: [
-        "package-dependencies/{package_dependencies_platform}/node_modules/sqlite3/build/Release/node_sqlite3.node",
-      ],
-      outputDir: "out/lib/bindings/node-v{node_modules_abi}-{bindings_suffix}/",
-      platforms: ["linux-x64", "linux-arm64", "darwin-arm64", "win32-x64"],
-    },
-    {
-      description:
         "SQLite3 binary libraries for {os} ({arch}) in platform-independent directory",
       inputFiles: [
         "package-dependencies/{package_dependencies_platform}/node_modules/sqlite3/build/Release/node_sqlite3.node",


### PR DESCRIPTION
create-package.js has the start of code to create a "fat" VSIX package that could potentially work on all supported platforms.

This is preliminary work and we don't even ship a npm script to generate that kind of package right now.

It also doesn't even really function, because sqlite3 uses the bindings module to find its own module and the bindings module mostly just looks in paths that don't encode the platform name. This means the bindings module doesn't really let us ship more than one set of platform specific sqlite3 files.

There is an exception: the bindings module will look in directories of the form:

lib/bindings/node-v$node_modules_abi-$platform

This would work except the node modules ABI changes fairly frequently and may be different at build time and run time.

create-package.js does install the sqlite3 module to that path, in the off chance the ABIs do match, but it even does it in the "slim", platform specific packages, making them bigger for no reason.

This commit drops the configuration entry to do that extra install of sqlite3. If we do revisit fat packages, we can potentially add it back, but only for the fat package and not the others.