### PR TITLE
More packaging fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "install-dependencies": "node scripts/install-dependencies.js",
     "build": "node scripts/build.js",
     "create-darwin-arm64-package": "node scripts/create-package.js --target darwin-arm64",
-    "create-darwin-x64-package": "node scripts/create-package.js --target darwin-x64",
     "create-linux-arm64-package": "node scripts/create-package.js --target linux-arm64",
     "create-linux-x64-package": "node scripts/create-package.js --target linux-x64",
     "create-win32-x64-package": "node scripts/create-package.js --target win32-x64",

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -374,17 +374,31 @@ async function runVsce(isRelease, target) {
   await runCommand("vsce: ", command);
 }
 
-async function main() {
-  const args = process.argv.slice(2);
-  let target;
+function parseCommandLine(args) {
+  let target = null;
+  let isRelease = false;
 
-  if (args[0] === "--target") {
-    target = args[1];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--target") {
+      if (i + 1 >= args.length) {
+        throw new Error("--target requires a platform argument");
+      }
+      target = args[i + 1];
+      i++;
+    } else if (args[i] === "--release") {
+      isRelease = true;
+    } else {
+      throw new Error(`Unknown argument: ${args[i]}`);
+    }
   }
-  const isRelease = args.includes("--release");
+
+  return { target, isRelease };
+}
+
+async function main() {
+  const { target, isRelease } = parseCommandLine(process.argv.slice(2));
 
   await fs.mkdir("build", { recursive: true });
-
   await purgePackageAssets();
   await buildSidebarUi();
   await copyPackageAssets(target);

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -127,7 +127,7 @@ const packageConfiguration = {
         "package-dependencies/{package_dependencies_platform}/node_modules/sqlite3/build/Release/node_sqlite3.node",
       ],
       outputDir: "out/build/Release",
-      platforms: [`${process.platform}-${process.arch}`],
+      platforms: ["linux-x64", "linux-arm64", "darwin-arm64", "win32-x64"],
     },
     {
       description:


### PR DESCRIPTION
I've hit a few more problems testing packaging:

1. We're shipping intel mac packages that don't work for a variety of reasons and couldn't work given how old the hardware is
2. We're not copying sqlite3 right
3. create-package.js expects command line arguments to occur in a prescribed order (yuck!)