### PR TITLE
Hopes are dashed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "granite-code",
+  "name": "granitecode",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -68,7 +68,7 @@ const namespaceTransformPlugin = makeTransformPlugin({
     },
     {
       pattern: /^Continue[.]continue$/,
-      replacement: "redhat.granite-code",
+      replacement: "redhat.granitecode",
     },
     {
       pattern: /continueGUI/,


### PR DESCRIPTION
The recent de-dashification of granite-code to granitecode was incomplete and broke the extension. This pull request addresses that.