### PR TITLE
scripts/build.js: Fix backwards arguments to minimatch

### DIFF
--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -297,7 +297,7 @@ function expandPackageConfigurationEntry(entry, variables, target) {
       !target ||
       entry.platforms?.some((platform) =>
         variableEntries.platforms.some((variablePlatform) =>
-          minimatch(platform, variablePlatform),
+          minimatch(variablePlatform, platform),
         ),
       );
     if (entry.platforms && !platformMatches) {


### PR DESCRIPTION
This fixes a problem where start_ollama.sh wasn't packaged (it was the only place where we globbed on platform.)