### PR TITLE
create-package.js: Use fs.promises.access() correctly

### DIFF
--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -226,11 +226,13 @@ async function processPackageConfigurationEntry(
 
       if (condition?.destinationExists !== undefined) {
         try {
-          const fileExists = await fs.access(destinationFile);
-          if (fileExists !== condition.destinationExists) {
-            continue;
-          }
+          await fs.access(destinationFile);
+          fileExists = true;
         } catch (error) {
+          fileExists = false;
+        }
+
+        if (fileExists !== condition.destinationExists) {
           continue;
         }
       }


### PR DESCRIPTION
fs.promises.access() rejects the promise with an Error instead of return false if the file doesn't exist.