### PR TITLE
ci: Fetch tags when cloning repo

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.events.inputs.EXTENSION_TAG }}
+          fetch-tags: true
 
       - name: Set Up NodeJS
         uses: actions/setup-node@v4


### PR DESCRIPTION
The publishing logic depends on tags being in the cloned repository to know which pre-release version to assign to the output package.

Unfortunately, GitHub by default does a shallow clone with no branches or tags.

This commit adds `fetch-tags: true` to ensure the tags are fetched at clone time.

Suggestion by Owen Taylor.