### PR TITLE
ci: Perform blobless clone instead of shallow clone

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.events.inputs.EXTENSION_TAG }}
-          fetch-tags: true
+          fetch-depth: 0
+          filter: blob:none
 
       - name: Set Up NodeJS
         uses: actions/setup-node@v4


### PR DESCRIPTION
The publishing logic depends on tags being in the cloned repository to know which pre-release version to assign to the output package.

Unfortunately, GitHub by default does a shallow clone with no branches or tags.

commit eb7855c52297e43fd25167c1859abd7fd4824d39 attempted to fix this issuing by using `fetch-tags: true` in the workflow yaml, but unfortunately that feature is currently broken:

https://github.com/actions/checkout/issues/1471

This commit instead, switches to using

fetch-depth: 0

to tell git not to do a shallow clone, and fetch tags.

To keep things performant it also adds:

filter: blob:none

to make files get fetched at git checkout time on deman instead of git clone time.