### PR TITLE
install-dependencies: Install correct in-tree modules

### DIFF
--- a/scripts/install-dependencies.js
+++ b/scripts/install-dependencies.js
@@ -63,11 +63,13 @@ const installConfiguration = {
         "package-dependencies/{package_dependencies_platform}/node_modules/sqlite3/build/Release/node_sqlite3.node",
       ],
       outputDir: "../build",
-    },
-    {
-      description: "Lancedb for in-tree testing",
-      inputModules: ["lancedb"],
-      outputDir: "../node_modules",
+      platforms: [`${process.platform}-${process.arch}`],
+     },
+     {
+       description: "Lancedb for in-tree testing",
+       inputModules: ["lancedb"],
+       outputDir: "../node_modules",
+       platforms: [`${process.platform}-${process.arch}`],
     },
     {
       description: "XML Http Request Worker",


### PR DESCRIPTION
The install-dependencies script installs in-tree node modules for testing Granite.Code directly in a VS Code environment.

It does this by putting the modules in build/ and node_modules/ of the repository root. This is distinct from where dependencies used for creating the installable VSIX package which go in package-dependencies/

commit 66c083e8e5ddbba43ae3fb18ec48a3c6bccd09dd makes install-dependencies a little smarter about what to do when there are no per-arch substitutions in the install source or destination.

It allowed us to drop platforms lines of the form:

platforms: [`${process.platform}-${process.arch}`],

which were just used to force the script to only perform an install of the specified source once, instead of once per arch.

The in-tree node modules also had platforms lines of that form, but for a different reason: they truly want to be installed for the current architecture and platform only.

Unfortunately, the aforementioned commit took those out as well, causing the wrong modules to get installed on macOS.

This commit fixes the problem by adding the platforms lines back.