### PR TITLE
create-package: Don't ship off-target ONNX files

### DIFF
--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -339,8 +339,6 @@ function expandPackageConfigurationEntry(entry, platforms, target) {
     },
   );
 
-  if (expandedEntries.length === 0) expandedEntries = [entry];
-
   return expandedEntries;
 }
 


### PR DESCRIPTION
create-package has a function expandPackageConfigurationEntry that takes a configuration entry (used for defining what gets packaged), and expands it include all platforms that are getting put in the package.

As a last ditch fallback, if it could find no platform to put in the package, it would just use the original, unexpanded entry.

This fallback is wrong, because it will trigger for platforms that are supposed to be filtered out when --target is used.

It's unnecessary when --target isn't used because there should be no fallback in that case (unless an unsupported platform was specified in the configuration, but that's not allowed anyway).

Likely, the fallback is a vestigial remanant of when the function was written a different way.

This commit drops it.