### PR TITLE
README.md: Fix typo after upstream link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is used to build the Granite.Code extension
 for Visual Studio Code.
 
 The Granite.Code vscode extension is based on
-[Continue](https://github.com/continuedev/continue),C
+[Continue](https://github.com/continuedev/continue),
 but with a number of changes, including:
 
 - A setup wizard that guides the user through downloading and installing Ollama and the Granite model.


### PR DESCRIPTION
There's inexplicably a capital C after the comma in that sentence that points users to the upstream continue.dev GitHub repository.

This commit drops the comma.