### PR TITLE
ci: deploy pre-releases to Open VSX

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,5 +73,11 @@ jobs:
           npx @vscode/vsce publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --pre-release -i build/*linux-x64*.vsix
           npx @vscode/vsce publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --pre-release -i build/*win32-x64*.vsix
 
+      - name: Publish Packages to VS Code Marketplace
+              run: |
+          npx ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --pre-release -i build/*darwin-arm64*.vsix
+          npx ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --pre-release -i build/*linux-x64*.vsix
+          npx ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --pre-release -i build/*win32-x64*.vsix
+
       - name: Push Pre-release
         run: git push origin --tags


### PR DESCRIPTION
Deploy pre-releases to https://open-vsx.org/, as part of the publish-packages CI job

Fixes #90 