### PR TITLE
ci: Fix indentation error in yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -74,7 +74,7 @@ jobs:
           npx @vscode/vsce publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --pre-release -i build/*win32-x64*.vsix
 
       - name: Publish Packages to VS Code Marketplace
-              run: |
+        run: |
           npx ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --pre-release -i build/*darwin-arm64*.vsix
           npx ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --pre-release -i build/*linux-x64*.vsix
           npx ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --pre-release -i build/*win32-x64*.vsix


### PR DESCRIPTION
commit 01d0c2d448d2f6f502f2f685ad7e8031848f143a introduced a stray indentation problem that is making the workflow fail.

This commit should fix things.