### PR TITLE
ci: Fix working for OpenVSX registry publishing step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
           npx @vscode/vsce publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --pre-release -i build/*linux-x64*.vsix
           npx @vscode/vsce publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --pre-release -i build/*win32-x64*.vsix
 
-      - name: Publish Packages to VS Code Marketplace
+      - name: Publish Packages to OpenVSX Registry
         run: |
           npx ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --pre-release -i build/*darwin-arm64*.vsix
           npx ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --pre-release -i build/*linux-x64*.vsix


### PR DESCRIPTION
The OpenVSX registry publishing step has a copy and paste error, so it says "VSCode Marketplace" instead of "OpenVSX Registry".

This commit fixes that.