### PR TITLE
Update to latest granite/integration

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,7 +36,22 @@
     },
 
     {
+      "label": "Build config-yaml",
+      "type": "shell",
+      "command": "npm",
+      "options": {
+        "cwd": "${workspaceFolder}/continue/packages/config-yaml"
+      },
+      "args": ["run", "build"],
+      "problemMatcher": [],
+      "group": {
+        "kind": "build"
+      }
+    },
+
+    {
       "label": "Build extension",
+      "dependsOn": ["Build config-yaml"],
       "type": "npm",
       "script": "build",
       "problemMatcher": [],
@@ -49,6 +64,7 @@
     // Start the React App for debugging with Vite
     {
       "label": "Dev GUI",
+      "dependsOn": ["Build config-yaml"],
       "type": "shell",
       "command": "npm",
       "options": {

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
           "default": false,
           "markdownDescription": "Pause Granite.Code's codebase index on start."
         },
+        "granite.enableConsole": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable a console to log and explore model inputs and outputs. It can be found in the bottom panel."
+        },
         "granite.remoteConfigServerUrl": {
           "type": "string",
           "default": null,
@@ -162,6 +167,12 @@
           ],
           "default": "large",
           "description": "Whether to use a small or large local model. Small models are faster but less accurate."
+        },
+        "granite.checkModelUpdates": {
+          "type": "boolean",
+          "default": true,
+          "title": "Check For Model Updates",
+          "description": "Controls whether a daily check is performed for Granite.Code model updates"
         }
       }
     },
@@ -291,17 +302,17 @@
         "enablement": "granite.initialized"
       },
       {
-        "command": "granite.navigateTo",
+        "command": "granite.clearConsole",
         "category": "Granite.Code",
-        "title": "Navigate to a path",
+        "title": "Clear Console",
+        "icon": "$(clear-all)",
         "group": "Granite.Code",
         "enablement": "granite.initialized"
       },
       {
-        "command": "granite.openMorePage",
+        "command": "granite.navigateTo",
         "category": "Granite.Code",
-        "title": "More",
-        "icon": "$(ellipsis)",
+        "title": "Navigate to a path",
         "group": "Granite.Code",
         "enablement": "granite.initialized"
       },
@@ -369,7 +380,7 @@
         "enablement": "granite.initialized"
       },
       {
-        "command": "granite.focusContinueSessionId",
+        "command": "granite.focusContinueInput",
         "category": "Granite.Code",
         "title": "Focus Granite.Code Chat",
         "group": "Granite.Code",
@@ -567,9 +578,14 @@
           "when": "view == granite.graniteGUIView"
         },
         {
-          "command": "granite.openMorePage",
-          "group": "navigation@6",
+          "command": "granite.openConfigPage",
+          "group": "navigation@4",
           "when": "view == granite.graniteGUIView"
+        },
+        {
+          "command": "granite.clearConsole",
+          "group": "navigation@1",
+          "when": "view == granite.graniteConsoleView"
         }
       ],
       "editor/title": [
@@ -598,6 +614,13 @@
           "title": "Granite.Code",
           "icon": "media/sidebar-icon.png"
         }
+      ],
+      "panel": [
+        {
+          "id": "graniteConsole",
+          "title": "Granite.Code Console",
+          "icon": "$(window)"
+        }
       ]
     },
     "views": {
@@ -608,6 +631,16 @@
           "name": "Granite.Code",
           "icon": "media/sidebar-icon.png",
           "visibility": "visible"
+        }
+      ],
+      "graniteConsole": [
+        {
+          "type": "webview",
+          "id": "granite.graniteConsoleView",
+          "name": "Granite.Code Console",
+          "icon": "$(window)",
+          "visibility": "visible",
+          "when": "config.granite.enableConsole"
         }
       ]
     },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -74,6 +74,10 @@ const namespaceTransformPlugin = makeTransformPlugin({
       pattern: /continueGUI/,
       replacement: "graniteGUI",
     },
+    {
+      pattern: /continueConsole/,
+      replacement: "graniteConsole",
+    },
   ],
 });
 

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -377,6 +377,12 @@ async function copyPackageAssets(target) {
   }
 }
 
+async function buildConfigYaml() {
+  console.log("\nBuilding @continuedev/config-yaml…");
+  const guiDir = path.resolve(projectRoot, "continue/packages/config-yaml");
+  await runCommand("npm: ", `${NPM} run build`, guiDir);
+}
+
 async function buildSidebarUi() {
   console.log("\nBuilding Sidebar UI…");
   const guiDir = path.resolve(projectRoot, "continue/gui/");
@@ -432,6 +438,7 @@ async function main() {
 
   await fs.mkdir("build", { recursive: true });
   await purgePackageAssets();
+  await buildConfigYaml();
   await buildSidebarUi();
   await copyPackageAssets(target);
   await runVsce(isRelease, target);

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -61,6 +61,7 @@ const packageConfiguration = {
       description: "Ollama launcher script",
       inputFiles: ["continue/core/util/start_ollama.sh"],
       platforms: ["linux-*"],
+      outputDir: "out/",
     },
     {
       description: "Tutorial file",

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -65,7 +65,7 @@ const packageConfiguration = {
     },
     {
       description: "Tutorial file",
-      inputFiles: ["continue/extensions/vscode/continue_tutorial.py"],
+      inputFiles: ["continue/extensions/vscode/granitecode_tutorial.py"],
     },
     {
       description: "x86-64 Linux binary libraries for reading ONNX files",

--- a/scripts/install-dependencies.js
+++ b/scripts/install-dependencies.js
@@ -11,6 +11,10 @@ let minimatch;
 const dependencyConfiguration = {
   entries: [
     {
+      description: "config-yaml dependencies",
+      packageDir: "./continue/packages/config-yaml",
+    },
+    {
       description: "Backend dependencies",
       packageDir: "./continue/core",
     },
@@ -64,12 +68,12 @@ const installConfiguration = {
       ],
       outputDir: "../build",
       platforms: [`${process.platform}-${process.arch}`],
-     },
-     {
-       description: "Lancedb for in-tree testing",
-       inputModules: ["lancedb"],
-       outputDir: "../node_modules",
-       platforms: [`${process.platform}-${process.arch}`],
+    },
+    {
+      description: "Lancedb for in-tree testing",
+      inputModules: ["lancedb"],
+      outputDir: "../node_modules",
+      platforms: [`${process.platform}-${process.arch}`],
     },
     {
       description: "XML Http Request Worker",

--- a/scripts/update-package-json.js
+++ b/scripts/update-package-json.js
@@ -29,7 +29,9 @@ function transform(data) {
   if (typeof data == "string") {
     let result = data.replace(/^continue$/, "granite");
     result = result.replace(/(^| )continue\./, "$1granite.");
+    result = result.replace(/(^| )config\.continue\./, "$1config\.granite.");
     result = result.replace(/continueGUI/, "graniteGUI");
+    result = result.replace(/continueConsole/, "graniteConsole");
     result = result.replace(/\bContinue\b/, "Granite.Code");
     // An exception - this is actually meant to be Continue
     result = result.replace(


### PR DESCRIPTION
Updates to latest granite/integration
 
 * Upstream UI changes to chat UI
 * Granite.Code configuration switched over to config.yaml from config.json
 * New logging console (needs to be enabled in settings)

Changes from the Granite.Code team (upstream and not)

Jazzcort (5):
      restore jazzcort's contextLength fix
      Fixed bug for pruning beyond last 5 messages
      Erased the extra condition
      Improved efficiency of one-third-pruning
      Forbid file mentioning for large files

Keerthana Panyam (2):
      rejected edit trims the trailing whitespaces
      remove redundant code

Fred Bricon (5):
      Fix Chat mode cycling on VS Code
      Disable Granite.Code when launching in Dev mode
      Enable tools support for Cogito on Ollama
      Mitigate registerCopyBufferSpy failures
      Fix 'undefined' this on files/changed listener

Owen W. Taylor:
      Reliably trigger VSCode extension rebuild
      pr_checks: write build timestamp before running tsc
      Granite.Code: merge our models and default context into config.yaml
      Granite.Code: Don't auto-add transformers.js embedding model
      Make the "Add Models" for the Lump models show the add model form
      Granite.Code: Auto-hide model selection and assistant selection dropdowns
      Always write a default config.yaml, even if config.json exists
      BaseLLM: don't disguise AbortError when rethrowing
      Revert "Add citations to the log"
      Add rich logging of LLM interactions
      LLMLogFormatter: rich logging to an output stream
      Console: limit number of interactions that we retain
      e2e: select quick picks based on strings, not harcoded indexes
      Granite.Code: disable tool autodetection for Granite 3
      Granite.Code: Never show "Create your first assistant"
      Hide tools UI when the model doesn't support installation
      Disable ability to add models and auto-hide rerank selector
      Update tests for "disable tool autodetection for Granite 3"
      binary: update typescript min version to match core
      setupGranitePage: set vscode global variable
