### PR TITLE
workflows/publish.yaml: Also build config-yaml here

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,9 @@ jobs:
           npm version $(git describe --tags --abbrev=0) --no-git-tag-version --allow-same-version
 
       - name: Build Extension
-        run: npm run build
+        run: |
+          (cd continue/packages/config-yaml && npm run build)
+          npm run build
 
       - name: Create Packages
         run: |


### PR DESCRIPTION
Just building the config-yaml package from the vscode tasks isn't sufficient.

Possibly it would be better if `npm run build` did this itself. That would require making the vscode tasks run in parallel - first run 'npm run build', *then* start vite.

But I think even better would be if upstream was fixed so that this package was fed as typescript source to the build process, and not separately compiled to JS.