### PR TITLE
Add negative lookahead to avoid some transforms

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -31,12 +31,15 @@ const makeTransformPlugin = ({ name, basePath, substitutions }) => {
     // using ts-morph or similar. We only care about simple strings
     // like "continue.acceptDiff", so we can simplify matching
     // strings in the source code.
-    return fileContents.replace(/"([^"\\\r\n]+)"/g, (m, strContents) => {
-      for (const { pattern, replacement } of substitutions) {
-        strContents = strContents.replace(pattern, replacement);
-      }
-      return '"' + strContents + '"';
-    });
+    return fileContents.replace(
+      /"([^"\\\r\n]+)"(?! *(?:\/\*|\/\/) *no-transform)/g,
+      (m, strContents) => {
+        for (const { pattern, replacement } of substitutions) {
+          strContents = strContents.replace(pattern, replacement);
+        }
+        return '"' + strContents + '"';
+      },
+    );
   };
 
   return {


### PR DESCRIPTION
According to @owtaylor 's suggestion, here we add the negative lookahead in the regex so we can add `no-transform` in the comment that is right after the string literal to avoid transform.
Details: https://github.com/Granite-Code/continue-for-granite/pull/39#issuecomment-2876933247