### PR TITLE
package.json: Drop down esbuild version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@vscode/vsce": "^3.2.2",
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.17.19",
         "minimatch": "^10.0.0",
         "prettier": "^3.4.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
@@ -185,7 +185,7 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.0",
+      "version": "0.17.19",
       "cpu": [
         "x64"
       ],
@@ -1072,7 +1072,7 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.0",
+      "version": "0.17.19",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1083,31 +1083,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.0",
-        "@esbuild/android-arm": "0.25.0",
-        "@esbuild/android-arm64": "0.25.0",
-        "@esbuild/android-x64": "0.25.0",
-        "@esbuild/darwin-arm64": "0.25.0",
-        "@esbuild/darwin-x64": "0.25.0",
-        "@esbuild/freebsd-arm64": "0.25.0",
-        "@esbuild/freebsd-x64": "0.25.0",
-        "@esbuild/linux-arm": "0.25.0",
-        "@esbuild/linux-arm64": "0.25.0",
-        "@esbuild/linux-ia32": "0.25.0",
-        "@esbuild/linux-loong64": "0.25.0",
-        "@esbuild/linux-mips64el": "0.25.0",
-        "@esbuild/linux-ppc64": "0.25.0",
-        "@esbuild/linux-riscv64": "0.25.0",
-        "@esbuild/linux-s390x": "0.25.0",
-        "@esbuild/linux-x64": "0.25.0",
-        "@esbuild/netbsd-arm64": "0.25.0",
-        "@esbuild/netbsd-x64": "0.25.0",
-        "@esbuild/openbsd-arm64": "0.25.0",
-        "@esbuild/openbsd-x64": "0.25.0",
-        "@esbuild/sunos-x64": "0.25.0",
-        "@esbuild/win32-arm64": "0.25.0",
-        "@esbuild/win32-ia32": "0.25.0",
-        "@esbuild/win32-x64": "0.25.0"
+        "@esbuild/aix-ppc64": "0.17.19",
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-arm64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-arm64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
       }
     },
     "node_modules/escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@vscode/vsce": "^3.2.2",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.17.19",
     "minimatch": "^10.0.0",
     "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.11",


### PR DESCRIPTION
The esbuild version that continue needs and granite.code needs should really match, otherwise npm may complain with an error like:

```
npm error code 1
npm error path /var/srv/sources/github/granite-code/continue/core/node_modules/esbuild
npm error command failed
npm error command sh -c node install.js
npm error /var/srv/sources/github/granite-code/continue/core/node_modules/esbuild/install.js:132
npm error     throw new Error(`Expected ${JSON.stringify(versionFromPackageJSON)} but got ${JSON.stringify(stdout)}`);
npm error           ^
npm error
npm error Error: Expected "0.17.19" but got "0.25.0"
npm error     at validateBinaryVersion (/var/srv/sources/github/granite-code/continue/core/node_modules/esbuild/install.js:132:11)
npm error     at /var/srv/sources/github/granite-code/continue/core/node_modules/esbuild/install.js:285:5
npm error
npm error Node.js v22.4.1
npm error A complete log of this run can be found in: /var/home/rstrode/.npm/_logs/2025-05-28T12_26_09_137Z-debug-0.log
```

This commit drops granite.code to the version used by continue to avoid this error, which bizarrely just started happening in the nighly builds.