### PR TITLE
extension.ts: Fix typo

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -27,7 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.commands.executeCommand("granite.viewLogs");
         } else if (selection === "Retry") {
           // Reload VS Code window
-          vcode.commands.executeCommand("workbench.action.reloadWindow");
+          vscode.commands.executeCommand("workbench.action.reloadWindow");
         }
       });
   });


### PR DESCRIPTION
Otherwise, it leads to:
```
  Cannot find name 'vcode'. Did you mean 'vscode'? ts(2552) [Ln 30,
      Col 11]
```

Fallout from b17613ccee72d768dc9836d94541a6794b0222ed